### PR TITLE
Fix sample model path and add toast feedback

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -25,9 +25,9 @@ app.add_middleware(
 )
 
 # Register models
-log("info", "🔍 About to register income model...")
-register_model(app=app, model_name="income", route_module=predict_income, endpoint="predict_income")
-log("info", "✅ Income model registered!")
+log("info", "🔍 About to register predict_income model...")
+register_model(app=app, model_name="predict_income", route_module=predict_income, endpoint="predict_income")
+log("info", "✅ predict_income model registered!")
 
 @app.get("/models")
 def list_models():

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -77,7 +77,7 @@ export const App: React.FC = () => {
         <nav className="px-4 py-3 border-b border-gray-200 dark:border-gray-700 flex justify-between items-center">
           <Link to="/" className="font-bold text-lg">ML API Dashboard</Link>
           <div className="space-x-4 flex items-center">
-            <a href="/docs" className="hover:underline">Docs</a>
+            <a href="/docs" className="hover:underline" target="_blank" rel="noreferrer">Docs</a>
             <a href="/models" className="hover:underline">Models API</a>
             <button onClick={() => setTheme(theme === 'dark' ? 'light' : 'dark')} className="border rounded px-2 py-1">
               {theme === 'dark' ? '🌞' : '🌙'}

--- a/frontend/src/pages/ModelPage.tsx
+++ b/frontend/src/pages/ModelPage.tsx
@@ -7,20 +7,36 @@ interface Props {
 export const ModelPage: React.FC<Props> = ({ model }) => {
   const [input, setInput] = useState<any>(model.example_input);
   const [result, setResult] = useState<any>(null);
+  const [toast, setToast] = useState<{ message: string; type: 'success' | 'error' } | null>(null);
   const validValues: Record<string, string[]> = model.valid_values || {};
 
   const handleChange = (key: string, value: any) => {
     setInput({ ...input, [key]: value });
   };
 
+  const showToast = (message: string, type: 'success' | 'error') => {
+    setToast({ message, type });
+    setTimeout(() => setToast(null), 3000);
+  };
+
   const handleSubmit = async () => {
-    const res = await fetch(model.endpoint, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(input),
-    });
-    const json = await res.json();
-    setResult(json);
+    setResult(null);
+    try {
+      const res = await fetch(model.endpoint, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(input),
+      });
+      const json = await res.json();
+      setResult(json);
+      if (res.ok) {
+        showToast('Done - OK', 'success');
+      } else {
+        showToast(`Done - Error (${res.status})`, 'error');
+      }
+    } catch (e) {
+      showToast('Done - Error', 'error');
+    }
   };
 
   const renderField = (key: string, def: any) => {
@@ -68,6 +84,15 @@ export const ModelPage: React.FC<Props> = ({ model }) => {
         <pre className="bg-gray-100 dark:bg-gray-800 p-2 rounded overflow-auto text-sm">
 {JSON.stringify(result, null, 2)}
         </pre>
+      )}
+      {toast && (
+        <div
+          className={`fixed bottom-4 right-4 px-4 py-2 rounded text-white ${
+            toast.type === 'success' ? 'bg-green-600' : 'bg-red-600'
+          }`}
+        >
+          {toast.message}
+        </div>
       )}
     </div>
   );

--- a/frontend/vite.config.mts
+++ b/frontend/vite.config.mts
@@ -14,6 +14,10 @@ export default defineConfig({
         target: 'http://127.0.0.1:8000',
         changeOrigin: true,
       },
+      '/docs': {
+        target: 'http://127.0.0.1:8000',
+        changeOrigin: true,
+      },
     },
   },
 });


### PR DESCRIPTION
## Summary
- register sample model under `predict_income` so frontend routing works
- fix docs link in the React navbar
- clear response and show toast status on submit
- proxy `/docs` in Vite dev server

## Testing
- `pytest -q`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6841e431ef3c833288cfb963ddb2afb8